### PR TITLE
Add bz2 decompression for non archive file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,10 @@ const fetchByteArray = async (url: string): Promise<Uint8Array> => {
 export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
   const wasmModule = await initializeWasm();
 
-  const extractData = async (data: Uint8Array, decompressOnly: boolean = false): Promise<FilesData> => {
+  const extractData = async (
+    data: Uint8Array,
+    decompressOnly: boolean = false
+  ): Promise<FilesData> => {
     /**Since WebAssembly, memory is accessed using pointers
       and the first parameter of extract_archive method from unpack.c, which is Uint8Array of file data, should be a pointer
       so we have to allocate memory for file data
@@ -71,7 +74,6 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
     }
     const filesPtr = wasmModule.getValue(resultPtr, 'i32');
     const fileCount = wasmModule.getValue(resultPtr + 4, 'i32');
-    
 
     /**
      * FilesPtr is a pointer that refers to an instance of the FileData in unpack.c
@@ -91,7 +93,7 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
       where `12` is the size of each FileData structure in memory in bytes: 4 + 4 + 4
     */
 
-    for (let i = 0; i <fileCount; i++) {
+    for (let i = 0; i < fileCount; i++) {
       const fileDataPtr = filesPtr + i * 12;
       const filenamePtr = wasmModule.getValue(fileDataPtr, 'i32');
       const dataSize = wasmModule.getValue(fileDataPtr + 8, 'i32');
@@ -102,11 +104,11 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
         dataPtr,
         dataSize
       );
-      
+
       const fileDataCopy = fileData.slice(0);
       files[filename] = fileDataCopy;
     }
-  
+
     wasmModule._free(inputPtr);
     wasmModule._free(fileCountPtr);
     wasmModule._free_extracted_archive(resultPtr);
@@ -114,27 +116,26 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
     fileCountPtr = null;
     resultPtr = null;
     errorMessagePtr = null;
-  
+
     return files;
-  
   };
 
   const extract = async (url: string): Promise<FilesData> => {
     let isArchive: boolean = checkIsArchive(url);
     const data = await fetchByteArray(url);
     return extractData(data, !isArchive);
-  }
+  };
 
-  const checkIsArchive = (url: string): boolean=>{
+  const checkIsArchive = (url: string): boolean => {
     let isArchive: boolean = false;
-    let archiveExtArr = ['.conda','tar.bz2', 'tar.gz'];
-    archiveExtArr.forEach((type)=>{
+    let archiveExtArr = ['.conda', 'tar.bz2', 'tar.gz'];
+    archiveExtArr.forEach(type => {
       if (url.toLowerCase().endsWith(type)) {
         isArchive = true;
       }
     });
     return isArchive;
-  }
+  };
 
   return {
     extract,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
 
   const extractData = async (
     data: Uint8Array,
-    decompressOnly: boolean = false
+    decompressionOnly: boolean = false
   ): Promise<FilesData> => {
     /**Since WebAssembly, memory is accessed using pointers
       and the first parameter of extract_archive method from unpack.c, which is Uint8Array of file data, should be a pointer
@@ -31,7 +31,7 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
       inputPtr,
       data.length,
       fileCountPtr,
-      decompressOnly
+      decompressionOnly
     );
     const files: FilesData = {};
     /**

--- a/src/unpack.d.ts
+++ b/src/unpack.d.ts
@@ -9,7 +9,7 @@ export interface IWasmModule {
     inputPtr: number,
     inputSize: number,
     fileCountPtr: number,
-    decompressedOnly: boolean
+    decompressionOnly: boolean
   ): number;
   getValue(ptr: number, type: string): number;
 }

--- a/src/unpack.d.ts
+++ b/src/unpack.d.ts
@@ -1,5 +1,4 @@
 export interface IWasmModule {
-  private _extract_data(inputPtr: number, length: number, fileCountPtr: number, decompressedOnly: boolean): number;
   wasmMemory: any;
   _free_extracted_archive(resultPtr: number): void;
   UTF8ToString(filenamePtr: number): string;
@@ -9,7 +8,8 @@ export interface IWasmModule {
   _extract_archive(
     inputPtr: number,
     inputSize: number,
-    fileCountPtr: number
+    fileCountPtr: number,
+    decompressedOnly: boolean
   ): number;
   getValue(ptr: number, type: string): number;
 }

--- a/src/unpack.d.ts
+++ b/src/unpack.d.ts
@@ -1,4 +1,5 @@
 export interface IWasmModule {
+  private _extract_data(inputPtr: number, length: number, fileCountPtr: number, decompressedOnly: boolean): number;
   wasmMemory: any;
   _free_extracted_archive(resultPtr: number): void;
   UTF8ToString(filenamePtr: number): string;

--- a/unpack.c
+++ b/unpack.c
@@ -21,7 +21,7 @@ typedef struct {
 
 
 EMSCRIPTEN_KEEPALIVE
-ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* fileCount, bool decompressOnly ) {
+ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* fileCount, bool decompressionOnly ) {
     struct archive* archive;
     struct archive_entry* entry;
     FileData* files = NULL;
@@ -40,7 +40,7 @@ ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* 
     archive = archive_read_new();
     archive_read_support_filter_all(archive);
     archive_read_support_format_all(archive);
-    if (decompressOnly) {
+    if (decompressionOnly) {
         archive_read_support_format_raw(archive);
     }
 
@@ -52,8 +52,8 @@ ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* 
     }
 
     while (archive_read_next_header(archive, &entry) == ARCHIVE_OK) {
-        const char* filename =  decompressOnly ? "decompression.json": archive_entry_pathname(entry);
-        size_t entrySize = decompressOnly ? inputSize: archive_entry_size(entry);
+        const char* filename =  decompressionOnly ? "decompression.json": archive_entry_pathname(entry);
+        size_t entrySize = decompressionOnly ? inputSize: archive_entry_size(entry);
         files= realloc(files, sizeof(FileData) * (files_count + 1));
         if (!files) {
             archive_read_free(archive);

--- a/unpack.c
+++ b/unpack.c
@@ -21,7 +21,7 @@ typedef struct {
 
 
 EMSCRIPTEN_KEEPALIVE
-ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* fileCount ) {
+ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* fileCount, bool decompressOnly ) {
     struct archive* archive;
     struct archive_entry* entry;
     FileData* files = NULL;
@@ -40,6 +40,9 @@ ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* 
     archive = archive_read_new();
     archive_read_support_filter_all(archive);
     archive_read_support_format_all(archive);
+    if (decompressOnly) {
+        archive_read_support_format_raw(archive);
+    }
 
     if (archive_read_open_memory(archive, inputData, inputSize) != ARCHIVE_OK) {
         result->status = 0;
@@ -49,10 +52,8 @@ ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* 
     }
 
     while (archive_read_next_header(archive, &entry) == ARCHIVE_OK) {
-        const char* filename = archive_entry_pathname(entry);
-        size_t entrySize = archive_entry_size(entry);
-
-   
+        const char* filename =  decompressOnly ? "decompression.json": archive_entry_pathname(entry);
+        size_t entrySize = decompressOnly ? inputSize: archive_entry_size(entry);
         files= realloc(files, sizeof(FileData) * (files_count + 1));
         if (!files) {
             archive_read_free(archive);
@@ -97,60 +98,6 @@ ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* 
     result->status = 1;
     return result;
 }
-
-EMSCRIPTEN_KEEPALIVE
-ExtractedArchive* decompress_bz2(const uint8_t* inputData, size_t inputSize) {
-    struct archive* a = archive_read_new();
-    struct archive_entry* entry;
-
-    archive_read_support_filter_bzip2(a);
-    archive_read_support_format_raw(a);
-
-    if (archive_read_open_memory(a, inputData, inputSize) != ARCHIVE_OK) {
-        fprintf(stderr, "Error opening bz2 file: %s\n", archive_error_string(a));
-        archive_read_free(a);
-        return NULL;
-    }
-
-    if (archive_read_next_header(a, &entry) != ARCHIVE_OK) {
-        fprintf(stderr, "Error reading bz2 header: %s\n", archive_error_string(a));
-        archive_read_free(a);
-    }
-
-    size_t totalSize = archive_entry_size(entry);
-    uint8_t* buffer = (uint8_t*)malloc(inputSize);
-    if (!buffer) {
-        fprintf(stderr, "Memory allocation error\n");
-        archive_read_free(a);
-    }
-
-    ssize_t bytesRead = archive_read_data(a, buffer, inputSize);
-    if (bytesRead < 0) {
-        fprintf(stderr, "Error decompressing bz2 file: %s\n", archive_error_string(a));
-        free(buffer);
-        archive_read_free(a);
-    }
-    ExtractedArchive* result = (ExtractedArchive*)malloc(sizeof(ExtractedArchive));
-    result->files = (FileData*)malloc(sizeof(FileData));
-    result->files[0].filename = strdup("decompressed.json");
-    result->files[0].data = buffer;
-    result->files[0].data_size = inputSize;
-    result->fileCount = 1;
-    result->status = 1;
-    result->error_message[0] = '\0';
-    archive_read_free(a);
-    return result;
-}
-
-EMSCRIPTEN_KEEPALIVE
-ExtractedArchive* extract_data(uint8_t* inputData, size_t inputSize, size_t* fileCount, bool decompressOnly) {
-    if (decompressOnly) {
-        return decompress_bz2(inputData, inputSize);
-    } else {
-        return extract_archive(inputData, inputSize, fileCount);
-    }
-}
-
 
 EMSCRIPTEN_KEEPALIVE
 void free_extracted_archive(ExtractedArchive* archive) {

--- a/unpack.c
+++ b/unpack.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <archive.h>
 #include <archive_entry.h>
 #include <emscripten.h>
@@ -18,8 +19,9 @@ typedef struct {
     char error_message[256];
 } ExtractedArchive;
 
+
 EMSCRIPTEN_KEEPALIVE
-ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* fileCount) {
+ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* fileCount ) {
     struct archive* archive;
     struct archive_entry* entry;
     FileData* files = NULL;
@@ -94,6 +96,59 @@ ExtractedArchive* extract_archive(uint8_t* inputData, size_t inputSize, size_t* 
     result->fileCount = files_count;
     result->status = 1;
     return result;
+}
+
+EMSCRIPTEN_KEEPALIVE
+ExtractedArchive* decompress_bz2(const uint8_t* inputData, size_t inputSize) {
+    struct archive* a = archive_read_new();
+    struct archive_entry* entry;
+
+    archive_read_support_filter_bzip2(a);
+    archive_read_support_format_raw(a);
+
+    if (archive_read_open_memory(a, inputData, inputSize) != ARCHIVE_OK) {
+        fprintf(stderr, "Error opening bz2 file: %s\n", archive_error_string(a));
+        archive_read_free(a);
+        return NULL;
+    }
+
+    if (archive_read_next_header(a, &entry) != ARCHIVE_OK) {
+        fprintf(stderr, "Error reading bz2 header: %s\n", archive_error_string(a));
+        archive_read_free(a);
+    }
+
+    size_t totalSize = archive_entry_size(entry);
+    uint8_t* buffer = (uint8_t*)malloc(inputSize);
+    if (!buffer) {
+        fprintf(stderr, "Memory allocation error\n");
+        archive_read_free(a);
+    }
+
+    ssize_t bytesRead = archive_read_data(a, buffer, inputSize);
+    if (bytesRead < 0) {
+        fprintf(stderr, "Error decompressing bz2 file: %s\n", archive_error_string(a));
+        free(buffer);
+        archive_read_free(a);
+    }
+    ExtractedArchive* result = (ExtractedArchive*)malloc(sizeof(ExtractedArchive));
+    result->files = (FileData*)malloc(sizeof(FileData));
+    result->files[0].filename = strdup("decompressed.json");
+    result->files[0].data = buffer;
+    result->files[0].data_size = inputSize;
+    result->fileCount = 1;
+    result->status = 1;
+    result->error_message[0] = '\0';
+    archive_read_free(a);
+    return result;
+}
+
+EMSCRIPTEN_KEEPALIVE
+ExtractedArchive* extract_data(uint8_t* inputData, size_t inputSize, size_t* fileCount, bool decompressOnly) {
+    if (decompressOnly) {
+        return decompress_bz2(inputData, inputSize);
+    } else {
+        return extract_archive(inputData, inputSize, fileCount);
+    }
 }
 
 


### PR DESCRIPTION
This PR includes the solution of https://github.com/emscripten-forge/untarjs/issues/35 if we have a non archive and we need to make bz2 decompression. For example, when we have *.json.bz2 file.
Earlier untarjs allowed to use the bz2 decompression only for archives.