### PR TITLE
Fix memory leaks, and reduce number of reallocs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,13 +24,10 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
     let inputPtr: number | null = wasmModule._malloc(data.length);
     wasmModule.HEAPU8.set(data, inputPtr);
 
-    // fileCountPtr is the pointer to 4 bytes of memory in WebAssembly's heap that holds fileCount value from the ExtractedArchive structure in unpack.c.
-    let fileCountPtr: number | null = wasmModule._malloc(4);
 
     let resultPtr: number | null = wasmModule._extract_archive(
       inputPtr,
       data.length,
-      fileCountPtr,
       decompressionOnly
     );
     const files: FilesData = {};
@@ -64,10 +61,8 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
         errorMessage
       );
       wasmModule._free(inputPtr);
-      wasmModule._free(fileCountPtr);
       wasmModule._free_extracted_archive(resultPtr);
       inputPtr = null;
-      fileCountPtr = null;
       resultPtr = null;
       errorMessagePtr = null;
       throw new Error(errorMessage);
@@ -110,10 +105,8 @@ export const initUntarJS = async (): Promise<IUnpackJSAPI> => {
     }
 
     wasmModule._free(inputPtr);
-    wasmModule._free(fileCountPtr);
     wasmModule._free_extracted_archive(resultPtr);
     inputPtr = null;
-    fileCountPtr = null;
     resultPtr = null;
     errorMessagePtr = null;
 

--- a/src/unpack.d.ts
+++ b/src/unpack.d.ts
@@ -8,7 +8,6 @@ export interface IWasmModule {
   _extract_archive(
     inputPtr: number,
     inputSize: number,
-    fileCountPtr: number,
     decompressionOnly: boolean
   ): number;
   getValue(ptr: number, type: string): number;


### PR DESCRIPTION
This fixes an issue with larger archives (probably the number of files is crucial) by reducing the number of reallocs.
Also, some unrelated memory leaks were found and removed. Also one unused argument was removed from the wasm function.